### PR TITLE
ci: CPU test gate for main (pytest-cpu required check)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [main]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: tests
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  pytest-cpu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-ci.txt
+      - name: Install CPU torch first (pin to CPU wheel index)
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - name: Install remaining dependencies
+        run: |
+          pip install -r requirements-ci.txt
+          pip install -e . --no-deps
+      - name: Run gated test suite
+        run: bash ci/run_ci_tests.sh

--- a/ci/collect_ignores.txt
+++ b/ci/collect_ignores.txt
@@ -1,1 +1,7 @@
 # test files excluded at collection time (module-level import errors).
+# imports adaptive_gradient_clip_ — absent from ptycho_torch.train_utils on main
+tests/torch/test_agc.py
+# imports compute_grad_norm — absent from ptycho_torch.train_utils on main
+tests/torch/test_grad_norm_utils.py
+# imports normalize_probe_like_tf — absent from ptycho_torch.helper on main
+tests/torch/test_probe_normalization_parity.py

--- a/ci/collect_ignores.txt
+++ b/ci/collect_ignores.txt
@@ -1,0 +1,1 @@
+# test files excluded at collection time (module-level import errors).

--- a/ci/collect_ignores.txt
+++ b/ci/collect_ignores.txt
@@ -1,4 +1,5 @@
 # test files excluded at collection time (module-level import errors).
+# One path per line; whole-line # comments only — no inline comments.
 # imports adaptive_gradient_clip_ — absent from ptycho_torch.train_utils on main
 tests/torch/test_agc.py
 # imports compute_grad_norm — absent from ptycho_torch.train_utils on main

--- a/ci/known_failures.txt
+++ b/ci/known_failures.txt
@@ -1,4 +1,5 @@
-# pytest node IDs excluded from the CI gate (one per line).
+# pytest node IDs excluded from the CI gate (one per line; whole-line # comments
+# only — no inline comments, they would corrupt the --deselect argument).
 # Ratchet: entries may be removed, never added without a reviewed justification comment.
 #
 # Baseline frozen from run 28567152991 (ubuntu-latest, CPU, commit cc18506e).

--- a/ci/known_failures.txt
+++ b/ci/known_failures.txt
@@ -1,2 +1,59 @@
 # pytest node IDs excluded from the CI gate (one per line).
 # Ratchet: entries may be removed, never added without a reviewed justification comment.
+#
+# Baseline frozen from run 28567152991 (ubuntu-latest, CPU, commit cc18506e).
+# needs CUDA
+tests/torch/test_cli_inference_torch.py::TestInferenceCLI::test_accelerator_flag_roundtrip
+# pre-existing failure on main (behavioral; fails identically in local GPU env)
+tests/torch/test_cli_train_torch.py::TestExecutionConfigCLI::test_bundle_persistence
+tests/torch/test_cli_train_torch.py::TestPatchStatsCLI::test_patch_stats_dump
+tests/torch/test_grad_norm_logging_flag.py::test_training_config_has_grad_norm_flags
+tests/torch/test_padded_size_no_jitter.py::test_get_padded_size_ignores_max_position_jitter
+tests/torch/test_parity_reassembly.py::test_reassembly_parity_simple_case
+tests/torch/test_reassemble_patches_position_real_c1.py::test_reassemble_patches_position_real_c1_uses_centermask_norm
+tests/torch/test_reassembly_crop_parity.py::test_reassembly_crop_matches_tf
+tests/torch/test_workflows_components.py::TestLightningCheckpointCallbacks::test_early_stopping_callback_configured
+tests/torch/test_workflows_components.py::TestLightningCheckpointCallbacks::test_model_checkpoint_callback_configured
+tests/torch/test_workflows_components.py::TestLightningExecutionConfig::test_monitor_uses_val_loss_name
+tests/torch/test_workflows_components.py::TestLightningExecutionConfig::test_trainer_receives_logger
+# pre-existing on main: InferenceConfig lacks log_patch_stats/patch_stats_limit fields
+tests/torch/test_patch_stats_cli.py::TestPatchStatsCLI::test_factory_creates_inference_config_with_patch_stats
+tests/torch/test_patch_stats_cli.py::TestPatchStatsCLI::test_factory_inference_config_defaults
+tests/torch/test_workflows_components.py::TestLightningExecutionConfig::test_trainer_receives_accumulation
+tests/torch/test_workflows_components.py::TestTrainWithLightningGreen::test_execution_config_controls_determinism
+tests/torch/test_workflows_components.py::TestTrainWithLightningGreen::test_execution_config_overrides_trainer
+tests/torch/test_workflows_components.py::TestTrainWithLightningRed::test_train_with_lightning_instantiates_module
+tests/torch/test_workflows_components.py::TestTrainWithLightningRed::test_train_with_lightning_returns_models_dict
+tests/torch/test_workflows_components.py::TestTrainWithLightningRed::test_train_with_lightning_runs_trainer_fit
+tests/torch/test_workflows_components.py::TestWorkflowsComponentsTraining::test_lightning_training_respects_gridsize
+# pre-existing on main: config dataclass lacks field the test passes
+tests/torch/test_loss_modes.py::test_mae_loss_mode_logs_mae_metrics_only
+tests/torch/test_loss_modes.py::test_poisson_loss_mode_logs_poisson_metrics
+tests/torch/test_model_training.py::test_configure_optimizers_supports_plateau
+tests/torch/test_physics_scale_loss.py::test_poisson_loss_uses_physics_scale
+# pre-existing on main: generator-adapter API absent from model.py
+tests/torch/test_generator_adapter.py::test_ptychopinn_predict_complex_real_imag
+tests/torch/test_generator_adapter.py::test_ptychopinn_with_custom_generator
+tests/torch/test_generator_adapter.py::test_real_imag_to_complex_channel_first
+tests/torch/test_generator_adapter.py::test_real_imag_to_complex_channel_first_invalid_shape
+tests/torch/test_generator_adapter.py::test_real_imag_to_complex_channel_first_with_imag
+# pre-existing on main: helper.derive_intensity_scale_from_amplitudes absent
+tests/torch/test_parity_intensity_scale.py::test_intensity_scale_parity
+tests/torch/test_physics_scale.py::test_derive_intensity_scale_from_amplitudes
+tests/torch/test_physics_scale_container.py::test_container_gets_physics_scale_value
+tests/torch/test_workflows_components.py::TestReassembleCdiImageTorchGreen::test_reassemble_cdi_image_torch_flip_transpose_contract[False-False-False]
+tests/torch/test_workflows_components.py::TestReassembleCdiImageTorchGreen::test_reassemble_cdi_image_torch_flip_transpose_contract[False-False-True]
+tests/torch/test_workflows_components.py::TestReassembleCdiImageTorchGreen::test_reassemble_cdi_image_torch_flip_transpose_contract[False-True-False]
+tests/torch/test_workflows_components.py::TestReassembleCdiImageTorchGreen::test_reassemble_cdi_image_torch_flip_transpose_contract[True-False-False]
+tests/torch/test_workflows_components.py::TestReassembleCdiImageTorchGreen::test_reassemble_cdi_image_torch_flip_transpose_contract[True-True-True]
+tests/torch/test_workflows_components.py::TestReassembleCdiImageTorchGreen::test_reassemble_cdi_image_torch_return_contract
+tests/torch/test_workflows_components.py::TestReassembleCdiImageTorchGreen::test_run_cdi_example_torch_do_stitching_delegates_to_reassemble
+tests/torch/test_workflows_components.py::TestWorkflowsComponentsTraining::test_coords_relative_layout
+tests/torch/test_workflows_components.py::TestWorkflowsComponentsTraining::test_lightning_poisson_count_contract
+# pre-existing on main: helper.normalize_probe_like_tf absent
+tests/torch/test_parity_probe_normalization.py::test_probe_normalization_parity
+# pre-existing on main: model._build_optimizer absent
+tests/torch/test_model_training.py::TestOptimizerSelection::test_configures_adam
+tests/torch/test_model_training.py::TestOptimizerSelection::test_configures_adamw
+tests/torch/test_model_training.py::TestOptimizerSelection::test_configures_sgd
+tests/torch/test_model_training.py::TestOptimizerSelection::test_invalid_optimizer_raises

--- a/ci/known_failures.txt
+++ b/ci/known_failures.txt
@@ -1,0 +1,2 @@
+# pytest node IDs excluded from the CI gate (one per line).
+# Ratchet: entries may be removed, never added without a reviewed justification comment.

--- a/ci/main-ruleset.json
+++ b/ci/main-ruleset.json
@@ -1,0 +1,29 @@
+{
+  "name": "main-test-gate",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {"include": ["refs/heads/main"], "exclude": []}
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [{"context": "pytest-cpu"}]
+      }
+    }
+  ]
+}

--- a/ci/run_ci_tests.sh
+++ b/ci/run_ci_tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# CI test gate: CPU-only, tracked-files-only subset of tests/torch.
+# Exclusion baseline: ci/known_failures.txt (node IDs -> --deselect),
+# ci/collect_ignores.txt (files -> --ignore). Policy: docs/ci.md.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export CUDA_VISIBLE_DEVICES=""
+
+args=(tests/torch -m "not slow" -q -rf --color=yes)
+
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  args+=(--deselect "$line")
+done < ci/known_failures.txt
+
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  args+=(--ignore "$line")
+done < ci/collect_ignores.txt
+
+# Extra args pass through to pytest (e.g. --collect-only, -k <expr>).
+python -m pytest "${args[@]}" "$@"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,48 @@
+# CI Test Gate (main)
+
+`main` only accepts changes through pull requests, and a PR only merges when
+the `pytest-cpu` check is green **against the current tip of main** (the
+ruleset's strict/up-to-date flag re-tests stale branches). Direct pushes and
+force pushes to main are rejected server-side by the `main-test-gate` ruleset
+(`ci/main-ruleset.json`).
+
+The ruleset is enforced on the public repo (`hoidn/PtychoPINN`), where
+rulesets are free. On the internal mirror the same workflow runs
+advisory-only: a red check is visible on every push and PR but cannot block.
+
+## What the gate runs
+
+`bash ci/run_ci_tests.sh` — `tests/torch`, CPU-only (`CUDA_VISIBLE_DEVICES=""`),
+`-m "not slow"`, minus the exclusion baseline:
+
+- `ci/known_failures.txt` — node IDs `--deselect`ed: tests needing CUDA,
+  untracked data (only git-tracked files exist in CI), or failing on main
+  before the gate existed.
+- `ci/collect_ignores.txt` — files `--ignore`d for module-level import errors.
+
+Reproduce locally with the same command. A green local conda run does NOT
+guarantee green CI (GPU and local data can mask failures); the CI environment
+is authoritative.
+
+## Ratchet policy
+
+The exclusion baseline may only shrink. Removing an entry (after fixing the
+test or its environment need) is always welcome. Adding an entry requires a
+PR whose diff includes a comment line stating why, and is reserved for tests
+that *cannot* pass in CI (new CUDA/data requirement) — never for silencing a
+regression.
+
+## When your PR is red
+
+1. Read the failing node IDs in the `pytest-cpu` log.
+2. If your change broke them: fix your change.
+3. If the test newly requires CUDA or untracked data: move that requirement
+   behind a skip-marker or add a baseline entry with justification (see
+   ratchet policy) — expect that to be challenged in review.
+
+## Known limitation
+
+Two PRs individually green can still break main together (semantic conflict);
+the strict up-to-date flag forces the second to re-test after the first
+merges, which closes this for serial merges. If merge volume ever makes that
+racy, enable a merge queue on the ruleset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ markers = [
     "torch: marks tests as requiring PyTorch (deselect with '-m \"not torch\"')",
     "optional: marks tests as requiring optional dependencies",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "oom: marks tests that intentionally exhaust memory (never run in CI)",
     "mvp: marks tests covering MVP (minimum viable product) field requirements",
     "study: marks tests for study infrastructure (STUDY-SYNTH-FLY64-DOSE-OVERLAP-001)",
     "mini: marks tests as minimal/fast unit tests",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -20,4 +20,6 @@ imageio
 numba
 tqdm
 ujson
-pytest
+# tests/conftest.py implements pytest_ignore_collect with the pre-pytest-8
+# (path=...) hookimpl signature; pytest 8 removed it. Pin to match.
+pytest<8

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -23,3 +23,5 @@ ujson
 # tests/conftest.py implements pytest_ignore_collect with the pre-pytest-8
 # (path=...) hookimpl signature; pytest 8 removed it. Pin to match.
 pytest<8
+# tensorflow-probability with TF>=2.16 imports Keras 2 via the tf-keras shim
+tf-keras

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,23 @@
+# CPU-only CI environment. Mirrors pyproject dependencies with GPU flavors
+# swapped out. Torch must be installed from the CPU index BEFORE this file
+# (see .github/workflows/tests.yml) or pip will pull the CUDA build.
+torch
+tensorflow-cpu
+tensorflow-probability
+tensordict
+lightning
+torchmetrics
+mlflow
+numpy
+scipy
+scikit-image
+scikit-learn
+matplotlib
+pandas
+Pillow
+dill
+imageio
+numba
+tqdm
+ujson
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,10 +78,13 @@ def pytest_ignore_collect(path, config):
     if "/tests/torch/" in p:
         try:
             import torch  # noqa: F401
-            return False
+            return None
         except Exception:
             return True
-    return False
+    # Return None (not False): pytest_ignore_collect is a firstresult hook, so
+    # returning False short-circuits pytest's built-in handler and silently
+    # disables --ignore/--ignore-glob for the entire suite.
+    return None
 
 def pytest_runtest_setup(item):
     """

--- a/tests/torch/test_loss_units.py
+++ b/tests/torch/test_loss_units.py
@@ -28,3 +28,7 @@ def test_mae_loss_squares_predictions():
 
     expected = torch.nn.functional.l1_loss(pred_amp ** 2, obs_intensity, reduction="none")
     assert torch.allclose(loss, expected)
+
+
+def test_ci_gate_tripwire_delete_me():
+    assert False, "deliberate red-path verification of the CI gate"

--- a/tests/torch/test_loss_units.py
+++ b/tests/torch/test_loss_units.py
@@ -28,7 +28,3 @@ def test_mae_loss_squares_predictions():
 
     expected = torch.nn.functional.l1_loss(pred_amp ** 2, obs_intensity, reduction="none")
     assert torch.allclose(loss, expected)
-
-
-def test_ci_gate_tripwire_delete_me():
-    assert False, "deliberate red-path verification of the CI gate"


### PR DESCRIPTION
Adds a CPU-only pytest gate that must pass before anything lands on main.

- `.github/workflows/tests.yml` — `pytest-cpu` job on every PR and push to main (ubuntu, py3.11, CPU torch/TF, ~4 min).
- `ci/run_ci_tests.sh` — runs `tests/torch -m "not slow"` with `CUDA_VISIBLE_DEVICES=""`, minus the frozen exclusion baseline.
- `ci/known_failures.txt` — 47 pre-existing failures on main (missing symbols, CUDA/data requirements), deselected under a ratchet policy: this list only shrinks.
- `ci/collect_ignores.txt` — 3 modules with dangling imports on main, ignored at collection.
- `tests/conftest.py` — one-line fix: `pytest_ignore_collect` returned `False` from its no-opinion branches, which (firstresult hook) silently disabled `--ignore`/`--ignore-glob` for the whole suite.
- `requirements-ci.txt` — CPU pins (`pytest<8`, `tf-keras`).

Enforced set: 136 passed / 15 skipped / 47 deselected (~43 s). Red-path verified: an injected failing test turned the check red; reverting restored green.

A follow-up commit on this branch adds the `main-test-gate` ruleset definition and `docs/ci.md` (policy of record).