### PR TITLE
docs: consistency pass — repair routing, dead links, and stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,268 +1,55 @@
 # CLAUDE.md - PtychoPINN Project Guide
 
 ## Project Overview
-**PtychoPINN** (Ptychographic Physics-Informed Neural Network) is a deep learning framework for coherent diffraction imaging reconstruction. It combines UNet-based encoder-decoder architectures with physics-informed forward models to reconstruct complex-valued objects from ptychographic diffraction measurements. The project uses PyTorch Lightning for training orchestration.
+**PtychoPINN** (Ptychographic Physics-Informed Neural Network) is a deep learning framework for coherent diffraction imaging reconstruction. It combines UNet-based encoder-decoder architectures with physics-informed forward models to reconstruct complex-valued objects from ptychographic diffraction measurements. Training is orchestrated with PyTorch Lightning.
 
-## Available Plugins
+## Environment & Scope
 
-### Context7 Documentation Plugin
-- Use `/pytorch/pytorch` for PyTorch documentation
-- Use `/lightning-ai/pytorch-lightning` for PyTorch Lightning documentation
-- Example: "query pytorch docs for nn.Module best practices"
+- Conda environment: `PtychoPINN_torch`, located at `/local/miniconda3/envs/PtychoPINN_torch`
+- **Only `ptycho_torch/` may be modified.** Other directories (e.g. `ptycho/`) contain other implementations we cannot and will not touch.
 
-### GitHub Plugin
-- Available for GitHub operations (issues, PRs, commits)
-- Project repo: `anthropics/claude-code` for feedback/issues
-
-### Conda environment
-The correct conda environment for python to import is called PtychoPINN_torch, located at `/local/miniconda3/envs/PtychoPINN_torch`
-
-## Directory Structure
+## Directory Layout
 
 ```
 ptycho_torch/
-├── api/              # High-level training/inference interfaces
-├── beta_modules/     # Experimental model variants (rectangular nets, UNet, scaling modules)
+├── api/              # High-level training/inference interfaces + usage examples
+├── beta_modules/     # Experimental variants: rectangular-coordinate net, UNet, weighted reassembly
+├── cli/              # Shared CLI helpers
 ├── configs/          # JSON configuration files for experiments
 ├── datagen/          # Synthetic data generation (objects, probes, diffraction)
-├── eval/             # Evaluation metrics (MSE, SSIM, FRC)
+├── eval/             # Evaluation metrics (PSNR, FRC/FSC)
+├── generators/       # Generator networks (cnn.py)
 └── notebooks/        # Analysis and manuscript figures
 ```
 
-Other directories such as ptycho contain other implementations that we cannot, and will not modify. We are concerned only with the ptycho_torch repository, which is the pytorch implementation of the architecture.
+Key top-level modules (read the source for API details — signatures drift faster than docs):
 
----
+- `model.py` — `PtychoPINN_Lightning` (main Lightning module), `Autoencoder`, `ForwardModel`, loss functions (Poisson, MAE, TV, MeanDeviation)
+- `model_attention.py` — CBAM/ECA attention blocks
+- `dataloader.py` — `PtychoDataset` (TensorDict memory-mapped, DDP-aware), `Collate_Lightning`
+- `patch_generator.py` — coordinate grouping (`group_coords`, quadrant/KDTree neighbor search)
+- `train_lightning_only.py` — `main()` training entry point (Lightning-only, no MLFlow)
+- `train_utils.py` — `PtychoDataModuleLightning`
+- `model_finetuner_modified.py` — `ModelFineTuner`, `StagedFineTuner_Lightning`
+- `inference.py`, `reassembly.py` — `reconstruct_image_barycentric()` and patch-assembly machinery
+- `beta_modules/reassembly.py` — `reconstruct_image_barycentric_weighted()`, `VarProScaler` (probe-weighted assembly + solved scaling constants)
+- `config_params.py` — `DataConfig`, `ModelConfig`, `TrainingConfig`, `InferenceConfig` dataclasses
+- `helper.py` — `reassemble_patches_position_real()`, sub-pixel `Translation()`
+- `datagen/datagen.py` — `simulate_multiple_experiments()`, `simulate_synthetic_objects()`, `simulate_synthetic_probes()`
+- `eval/eval_metrics.py`, `eval/frc.py` — PSNR, FSC (van Heel & Schatz 2005)
 
-## Core Files
+## Configuration Gotchas
 
-### Model Architecture (`model.py`, `beta_modules/model_unet.py`)
-
-**PtychoPINN_Lightning** - Main Lightning module for training
-- Multi-stage training with configurable RMS/physics normalization weights
-- Automatic gradient accumulation and clipping for DDP
-- Supports supervised and unsupervised modes
-- Methods: `freeze_encoder()`, `get_encoder_bottom_params()`, `print_trainable_status()`
-
-**Autoencoder** - Base encoder-decoder architecture with skip connections for U-net
-- Encoder: ConvPoolBlock layers with optional CBAM/ECA attention
-- Decoder_amp: Amplitude decoder with SiLU activation
-- Decoder_phase: Phase decoder with tanh activation (batch norm enabled)
-- Forward: Returns (amplitude, phase) tuple
-
-**ForwardModel** - Physics-informed forward pass
-- Reassembles patches using `reassemble_patches_position_real()`
-- Applies probe illumination via hadamard product
-- Performs FFT to simulate diffraction
-- Optional trainable intensity scaling per dataset (mandatory for model_unet.py)
-
-**Loss Functions**
-- PoissonLoss: Negative log-likelihood for photon counting
-- MAELoss: Mean absolute error on intensities
-- TotalVariationLoss: Smoothness regularization
-- MeanDeviationLoss: Penalizes amplitude/phase variations
-
----
-
-### Attention Mechanisms (`model_attention.py`)
-
-**CBAM** (Convolutional Block Attention Module)
-- ChannelGate: MLP-based channel attention with avg/max pooling
-- SpatialGate: Conv-based spatial attention (kernel size 7)
-- Used in encoder (optional), bottleneck, and decoder
-
----
-
-### Data Loading (`dataloader.py`)
-
-**PtychoDataset** - Memory-mapped dataset for large ptychography scans
-- Creates TensorDict memory maps for efficient I/O
-- Handles multi-experiment datasets with coordinate filtering
-- Supports DDP with rank-aware map creation
-- Fields: images, coords_global, coords_relative, nn_indices, scaling_constant
-- Methods: `get_experiment_dataset()` to index specific dataset for multi-dataset construction
-
-**Coordinate Grouping** (`patch_generator.py`)
-- `group_coords()`: Creates overlapping patch groups for physics constraints
-- `get_fixed_quadrant_neighbors_c4()`: 4-quadrant sampling for rectangular scans with fixed relative positioning
-- `get_neighbors_indices_within_bounds()`: KDTree-based neighbor search with distance filters
-
-**Collate_Lightning**
-- Pin memory for CUDA transfers
-- Device-agnostic (Lightning handles placement)
-
----
-
-### Training (`train_lightning_only.py`, `train_utils.py`)
-
-**main()** - Lightning-only training (no MLFlow)
-- Creates TensorBoard/CSV loggers with unified run naming
-- Configurable multi-GPU via DDPStrategy
-- Checkpoint callbacks with best/last model saving
-- Optional fine-tuning with frozen encoder
-
-**PtychoDataModuleLightning**
-- `prepare_data()`: Rank 0 creates memory map
-- `setup()`: All ranks load existing map (Lightning adds barrier)
-- Returns train/val dataloaders with persistent workers
-
-**ModelFineTuner** (`model_finetuner_modified.py`)
-- Freezes encoder, scales LR by `fine_tune_gamma`
-- Creates separate run directory for fine-tuning stage
-- Logs configs and metadata via Lightning callbacks
-
-**StagedFineTuner_Lightning** (Beta)
-- Stage 1: Decoder-only (adapt object space)
-- Stage 2: Partial encoder + discriminative LR
-- Stage 3: Full network with conservative LR
-- Configurable per-stage LR multipliers
-
----
-
-### Inference & Reconstruction (`inference.py`, `reassembly.py`, `beta_modules/reassembly.py`)
-
-**reconstruct_image_barycentric()** - Multi-GPU reconstruction
-- Vectorized barycentric interpolation for patch assembly
-- Mixed precision support (FP16/FP32)
-- DataParallel wrapper for multi-GPU inference
-- Returns assembled canvas with normalized counts
-
-**reconstruct_image_barycentric_weighted()** - Multi-GPU reconstruction in beta modules
-- Vectorized barycentric interpolation for patch assembly
-- Weighted by probe intensities instead of pixel-dependent image contribution count
-- Accumulates predicted intensities and actual intensities for fitting by VarProScaler
-- Returns scaled, assembled canvas with solved physics scaling constants
-
-**reassemble_multi_channel()**
-- Assembles overlapping patches into solution regions
-- Translates solution patches to global canvas
-- Weighted averaging based on overlap counts
-
-**VectorizedBarycentricAccumulator**
-- Bilinear interpolation weights for sub-pixel positioning
-- Scatter-add operations for efficient accumulation
-- Handles bounds checking for patch validity
-
-**VectorizedWeightedccumulator**
-- Identical to VectorizedBarycentricAccumulator except for weighted normalization canvas
-- Uses probe magnitude to calculate normalization weights
-
-**VarProScaler**
-- Accumulates predicted and real intensity values for whole dataset during inference
-- Uses various optimization methods (e.g. Newton, LBFGS) to solve for photon scaling constants
-
----
-
-### Data Generation (`datagen/datagen.py`, `datagen/objects.py`)
-
-**simulate_multiple_experiments()**
-- Generates synthetic datasets with controllable parameters
-- Saves: diff3d, label, objectGuess, probeGuess, coords
-- Supports batch processing with timing metrics
-
-**Synthetic Object Methods**
-- `create_dead_leaves()`: Overlapping shapes with realistic textures
-- `create_white_noise_object()`: Blurred noise with material parameters
-- `create_simplex_noise_object()`: Perlin/simplex noise-based structures
-- `generate_perlin_object()`: Batch generation with correlated amp/phase
-
-**Probe Generation** (`datagen/probe.py`)
-- `generate_random_zernike()`: Zernike polynomial-based probes
-- `generate_random_fzp()`: Fresnel zone plate probes
-- Optional ramp removal and normalization
-
----
-
-### Configuration (`config_params.py`)
-
-**DataConfig**
-- N: Diffraction pattern size (64/128/256)
-- C: Number of channels (1=CDI, 4=ptychography)
-- normalize: 'Batch' or 'Group' normalization strategy
-- x_bounds, y_bounds: Coordinate filtering (avoid edges)
-- scan_pattern: Matches experiment scan pattern, common failure mode if scan pattern is NOT matched
-
-**ModelConfig**
-- mode: 'Supervised' or 'Unsupervised'
-- loss_function: 'Poisson' or 'MAE'
-- cbam_encoder/decoder: Enable CBAM attention
-- object_big: Enable overlap constraint (True when C > 1)
-
-**TrainingConfig**
-- epochs, learning_rate, batch_size
-- stage_1/2/3_epochs: Multi-stage normalization schedule
-- scheduler: 'Cosine', 'MultiStage', 'Adaptive'
-- enable_staged_finetuning: Cross-domain transfer learning
-
-**InferenceConfig**
-- middle_trim: Central region size for reconstruction
-- batch_size: Inference batch size (reduce for memory)
-- experiment_number: Dataset index for multi-experiment inference
-
----
-
-### Utilities (`helper.py`, `utils.py`)
-
-**reassemble_patches_position_real()** (`helper.py`)
-- Translates patches to global coordinates
-- Aggregates overlaps with weighted averaging
-- Returns merged canvas + validity mask
-
-**Translation()** (`helper.py`)
-- Sub-pixel translation using grid_sample
-- Supports complex tensors via split real/imag
-- Jitter support for data augmentation
-
-**config_to_json_serializable_dict()** (`utils.py`)
-- Converts dataclasses to JSON (skips Tensors)
-- Used for checkpoint metadata logging
-
-**load_all_configs_from_mlflow()** (`utils.py`)
-- Deserializes configs from MLFlow run parameters
-- Post-processing for legacy attribute fixes
-
----
-
-### Evaluation (`eval/eval_metrics.py`, `eval/frc.py`)
-
-**FSC()** - Fourier Shell Correlation
-- Frequency-domain resolution metric
-- Returns FSC curve, threshold, and spatial frequencies
-- Based on van Heel & Schatz (2005)
-
-**PSNR()** - Peak Signal-to-Noise Ratio
-- Separate metrics for amplitude and phase
-- Energy-based normalization for fair comparison
-- Phase normalized to [0, 1] via 2π wrapping
-
----
-
-## Beta Modules
-
-### `beta_modules/model.py` - Rectangular Coordinate Net
-- Specialized for anisotropic scan patterns
-- Custom quadrant-based coordinate grouping
-- Modified reassembly for non-square grids
-
-### `beta_modules/model_unet.py` - UNet Variant
-- Skip connections between encoder/decoder
-- Residual blocks with batch normalization
-- Alternative architecture for comparison
-
-### `beta_modules/reassembly.py` - Weighted Reassembly
-- Probe-weighted patch assembly
-- Circular mean for phase averaging
-- S1/S2 scaling factor optimization (Newton's method)
-
----
+- `DataConfig.scan_pattern` must match the experiment's scan pattern — mismatch is a common failure mode
+- `DataConfig.C`: 1 = CDI, 4 = ptychography; `ModelConfig.object_big` (overlap constraint) should be True when C > 1
+- `DataConfig.x_bounds` / `y_bounds` filter edge scan positions
 
 ## Common Patterns
 
 ### Training a Model
 ```python
-from ptychopinn_torch.train_lightning_only import main
-from ptychopinn_torch.utils import load_config_from_json
+from ptycho_torch.train_lightning_only import main
 
-# Load config and train
 run_dir = main(
     ptycho_dir='data/synthetic/',
     config_path='configs/my_config.json',
@@ -272,16 +59,13 @@ run_dir = main(
 
 ### Inference on New Data
 ```python
-from ptychopinn_torch.lightning_utils import load_checkpoint_with_configs
-from ptychopinn_torch.reassembly import reconstruct_image_barycentric
+from ptycho_torch.lightning_utils import load_checkpoint_with_configs
+from ptycho_torch.reassembly import reconstruct_image_barycentric
 
-# Load model
 model, configs = load_checkpoint_with_configs(
     'training_outputs/.../best-checkpoint.ckpt',
     PtychoPINN_Lightning
 )
-
-# Reconstruct
 canvas, dataset, stats = reconstruct_image_barycentric(
     model, ptycho_dataset,
     training_config, data_config, model_config, inference_config
@@ -290,28 +74,23 @@ canvas, dataset, stats = reconstruct_image_barycentric(
 
 ### Generating Synthetic Data
 ```python
-from ptychopinn_torch.datagen.datagen import simulate_multiple_experiments
-from ptychopinn_torch.datagen.objects import simulate_synthetic_objects
-from ptychopinn_torch.datagen.probe import simulate_synthetic_probes
+from ptycho_torch.datagen.datagen import (
+    simulate_multiple_experiments, simulate_synthetic_objects, simulate_synthetic_probes
+)
 
-# Create objects and probes
 obj_list = simulate_synthetic_objects(
-    img_shape=(250,250), data_config=data_config,
+    img_shape=(250, 250), data_config=data_config,
     nimages=10, obj_method='dead_leaves', obj_arg={}
 )
 probe_list = simulate_synthetic_probes(
     data_config, nimages=10, probe_method='zernike', probe_arg={}
 )
-
-# Generate datasets
 simulate_multiple_experiments(
     obj_list, probe_list, images_per_experiment=5000,
-    img_shape=(250,250), data_config=data_config,
+    img_shape=(250, 250), data_config=data_config,
     probe_arg={}, save_dir='data/synthetic/'
 )
 ```
-
----
 
 ## Coding Conventions
 
@@ -322,7 +101,8 @@ simulate_multiple_experiments(
 5. **Logging**: Use `print()` with rank guards: `if is_effectively_global_rank_zero():`
 6. **Device Placement**: Lightning handles `.to(device)`, but dataloaders need explicit pin_memory
 
----
+## Repo conventions 
+- don't mention claude or claude code in commit messages 
 
 ## Key Architecture Decisions
 
@@ -332,8 +112,6 @@ simulate_multiple_experiments(
 - **Memory-Mapped Datasets**: TensorDict enables multi-TB datasets without RAM limits
 - **Probe-Weighted Assembly**: Uses |Probe|² for physically accurate overlap weighting
 - **Incoherent Multi-Mode Probes**: The beta modules (`model_unet.py`, `reassembly.py`) support multiple incoherent probe modes via the tensor layout `[B, C, P, H, W]` where P is the probe mode dimension. The dataloader auto-detects 2D (single-mode) vs 3D (multi-mode) probes from NPZ files. The forward model uses incoherent summation: $I = \sum_p |\mathcal{F}\{O \cdot P_p\}|^2$. For inference assembly, stitching weights use total probe intensity $W(\mathbf{r}) = \sum_p |P_p(\mathbf{r})|^2$. The VarPro scaler computes mode-summed basis images before solving for scaling constants. All changes are backward-compatible — when P=1, behavior is identical to the single-mode case.
-
----
 
 ## Common Issues
 
@@ -347,19 +125,20 @@ simulate_multiple_experiments(
 
 **"Model gradients are NaN"**
 - Check `gradient_clip_val` is set (recommend 1.0-5.0)
-- Reduce learning rate or increase `stage_1_epochs`
+- Reduce learning rate or increase `finetune_stage1_epochs`
 
 **"Reconstruction has stitching artifacts"**
 - Increase `middle_trim` (32 → 48 for N=64)
 - Check probe normalization is disabled during inference
 - Verify `x_bounds`/`y_bounds` filter edge positions
 
----
+## Plugins
+
+- **Context7**: `/pytorch/pytorch` and `/lightning-ai/pytorch-lightning` for library docs
+- **GitHub**: available for issues/PRs/commits
 
 ## Thinking Scaffolding
 
 **Ensure physics and scientific rigor**
-- Ensure suggestions are grounded in physics and have mathematical rigor
-- Format scientific explanatory outputs with latex-compatible formatting (e.g. equations)
-
-
+- Ground suggestions in physics with mathematical rigor
+- Format scientific explanatory outputs with LaTeX-compatible equations

--- a/README.md
+++ b/README.md
@@ -52,13 +52,6 @@ PtychoPINN supports both TensorFlow and PyTorch backends:
   - Unified scripts: use `--torch-accelerator` and `--torch-logger`
   - PyTorch-native CLIs: use `--accelerator` and `--logger`
 
-#### Also Supported
-- Grid-lines multi-model runs:
-  - `scripts/studies/grid_lines_compare_wrapper.py`
-- Grid-lines Torch runner:
-  - `scripts/studies/grid_lines_torch_runner.py`
-  - Architectures: `fno`, `hybrid`, `stable_hybrid`, `fno_vanilla`, `hybrid_resnet`
-
 #### Older Flags and Modes
 - `--n_images` in training is older; use `--n_groups`.
 - PyTorch `--device` and `--disable_mlflow` are older; use `--accelerator` and `--logger none`.

--- a/docs/COMMANDS_REFERENCE.md
+++ b/docs/COMMANDS_REFERENCE.md
@@ -1,6 +1,3 @@
-### `docs/COMMANDS_REFERENCE.md` 
-
-```markdown
 # PtychoPINN Commands Reference
 
 **Purpose:** A quick reference for essential PtychoPINN command-line workflows. This guide provides the "what"; for the "why," please consult the linked detailed guides.
@@ -211,44 +208,7 @@ python scripts/reconstruction/ptychi_reconstruct_tike.py
 
 ## Model Evaluation
 
-```bash
-# Basic model evaluation (single model against ground truth)
-ptycho_evaluate --model-dir trained_model/ --test-data test.npz --output-dir eval_results
-
-# Evaluation with sampling control (NEW)
-ptycho_evaluate --model-dir trained_model/ --test-data test.npz --n-test-subsample 2000 --n-test-groups 500 --output-dir eval_results
-
-# Custom visualization settings
-ptycho_evaluate --model-dir model/ --test-data test.npz --output-dir eval_vis \
-    --phase-align-method plane --save-individual-images --phase-colormap viridis
-
-# Skip registration for debugging
-ptycho_evaluate --model-dir model/ --test-data test.npz --output-dir eval_debug --skip-registration
-
-# Quiet mode for automation
-ptycho_evaluate --model-dir model/ --test-data test.npz --output-dir eval_auto --quiet
-```
-
-### 📊 Key Features
-
-- **Comprehensive Metrics**: Computes MAE, MSE, PSNR, SSIM, MS-SSIM, and FRC against ground truth
-- **Automatic Registration**: Aligns reconstructions with ground truth for fair comparison
-- **Visual Outputs**: Generates amplitude/phase plots, error maps, and comparison figures
-- **CSV Export**: Saves all metrics to `results.csv` for downstream analysis
-- **Independent Sampling**: Control test data subsampling with `--n-test-subsample` and `--n-test-groups`
-
-### 📋 When to Use Model Evaluation vs Comparison
-
-- **Use `ptycho_evaluate`** when:
-  - Evaluating a single trained model against ground truth
-  - Computing detailed metrics for model analysis
-  - Creating publication-ready visualizations
-  - Debugging model performance issues
-
-- **Use `compare_models.py`** when:
-  - Comparing multiple models head-to-head
-  - Benchmarking PtychoPINN vs Baseline vs Tike
-  - Running systematic model comparisons
+Model evaluation is currently performed via the comparison/study scripts (see `scripts/studies/README.md`); there is no `ptycho_evaluate` console command.
 
 ---
 
@@ -365,5 +325,4 @@ tail -f output_dir/logs/debug.log
 nvidia-smi
 ```
 
-For detailed explanations, see the <doc-ref type="guide">docs/DEVELOPER_GUIDE.md</doc-ref> and <doc-ref type="guide">docs/TOOL_SELECTION_GUIDE.md</doc-ref>.
-```
+For detailed explanations, see the <doc-ref type="guide">docs/DEVELOPER_GUIDE.md</doc-ref>.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,5 +1,7 @@
 # PtychoPINN Configuration Guide
 
+> **Scope:** This guide documents the configuration system of the legacy TensorFlow implementation (`ptycho/config/config.py`). The active PyTorch implementation (`ptycho_torch/`) uses separate dataclasses in `ptycho_torch/config_params.py` — see the project CLAUDE.md for its fields and gotchas.
+
 This document is the canonical reference for all configuration parameters used in the PtychoPINN project. It details the modern dataclass-based configuration system and provides a comprehensive reference for all available parameters.
 
 ## The Configuration System
@@ -60,7 +62,7 @@ These parameters control the training loop, data handling, and loss functions.
 | `realspace_mae_weight` | `float` | `0.0` | Weight for the MAE loss in the object domain. |
 | `realspace_weight` | `float` | `0.0` | General weight for all real-space losses. |
 | `nphotons` | `float` | `1e9` | The target average number of photons per diffraction pattern, used for the Poisson noise model. |
-| `n_groups` | `int` | `512` | Number of groups to use from the dataset. Each group contains 1 image for gridsize=1, or gridsize² images for gridsize>1. **Replaces deprecated `n_images` parameter.** |
+| `n_groups` | `Optional[int]` | `None` | Number of groups to use from the dataset. Each group contains 1 image for gridsize=1, or gridsize² images for gridsize>1. **Replaces deprecated `n_images` parameter.** |
 | `n_images` | `int` | `None` | **[DEPRECATED]** Legacy parameter name for `n_groups`. Still supported for backward compatibility but will show deprecation warnings. New code should use `n_groups`. |
 | `n_subsample` | `Optional[int]` | `None` | Number of images to subsample from the dataset before grouping (independent control). When provided, controls data selection separately from grouping. |
 | `subsample_seed` | `Optional[int]` | `None` | Random seed for reproducible subsampling. Ensures consistent data selection across runs. |

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -245,8 +245,6 @@ Use these docs directly instead of reinventing diagnostics:
   - `docs/TROUBLESHOOTING.md`
 - Params/config quick checks:
   - `docs/QUICK_REFERENCE_PARAMS.md`
-- Known historical issues and policy IDs:
-  - `docs/findings.md`
 
-If you discover a recurring issue, add it to `docs/findings.md` with evidence.
+If you discover a recurring issue, add it to `docs/TROUBLESHOOTING.md` with evidence.
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -11,16 +11,15 @@ Use this document for:
 - code review expectations
 
 For command recipes, see `docs/COMMANDS_REFERENCE.md`.
-For full troubleshooting playbooks, see `docs/debugging/TROUBLESHOOTING.md`.
+For full troubleshooting playbooks, see `docs/TROUBLESHOOTING.md`.
 
 ## Quick Start Checklist
 
 Before editing code:
 1. Read `docs/index.md`.
-2. Read `docs/findings.md`.
-3. Identify whether your change touches TensorFlow, PyTorch, or both.
-4. Confirm required contracts in `specs/data_contracts.md` and relevant specs.
-5. Choose a focused pytest selector and keep logs as evidence.
+2. Identify whether your change touches TensorFlow, PyTorch, or both.
+3. Confirm required contracts in `docs/data_contracts.md` and relevant specs.
+4. Choose a focused pytest selector and keep logs as evidence.
 
 ---
 
@@ -98,8 +97,7 @@ If edits are required, add focused regression tests and document the rationale.
 NPZ/HDF5 structures are external contracts, not implementation details.
 
 Authoritative sources:
-- `specs/data_contracts.md`
-- `specs/ptychodus_api_spec.md`
+- `docs/data_contracts.md`
 
 Do not "fix" malformed inputs deep in the pipeline unless the contract explicitly allows adaptation.
 
@@ -162,10 +160,6 @@ Use these primary entrypoints:
 
 Backend selection is explicit via config/CLI (`tensorflow` or `pytorch`) and routed through backend selectors/workflow components.
 
-For grid-lines study workflows:
-- orchestrator: `scripts/studies/grid_lines_compare_wrapper.py`
-- torch runner: `scripts/studies/grid_lines_torch_runner.py`
-
 Prefer modern flags and paths; keep legacy flags only for compatibility.
 
 ---
@@ -179,7 +173,6 @@ Project standard:
 
 Primary references:
 - `docs/TESTING_GUIDE.md`
-- `docs/development/TEST_SUITE_INDEX.md`
 
 Baseline expectations for production-path changes:
 1. targeted unit/regression tests
@@ -249,15 +242,11 @@ Migration guidance:
 Use these docs directly instead of reinventing diagnostics:
 
 - Common failures:
-  - `docs/debugging/TROUBLESHOOTING.md`
+  - `docs/TROUBLESHOOTING.md`
 - Params/config quick checks:
-  - `docs/debugging/QUICK_REFERENCE_PARAMS.md`
+  - `docs/QUICK_REFERENCE_PARAMS.md`
 - Known historical issues and policy IDs:
   - `docs/findings.md`
-- Data generation behavior:
-  - `docs/DATA_GENERATION_GUIDE.md`
-- PyTorch workflow behavior:
-  - `docs/workflows/pytorch.md`
 
 If you discover a recurring issue, add it to `docs/findings.md` with evidence.
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -35,7 +35,7 @@ Fast, focused tests that validate individual components and functions in isolati
 - **Examples:**
   - `test_cli_args.py` - Tests command-line argument parsing
   - `test_misc.py` - Tests utility functions
-  - `test_model_manager.py` - Tests model management functionality
+  - `test_model_manager_persistence.py` - Tests model management functionality
   - `test_tf_helper.py` - Tests TensorFlow helper functions
 - **Execution time:** Typically < 1 second per test
 - **Dependencies:** Minimal, often using mocks or small test fixtures
@@ -76,7 +76,7 @@ This test ensures that:
 
 To run a specific test file:
 ```bash
-python -m unittest tests.test_model_manager
+python -m unittest tests.test_model_manager_persistence
 ```
 
 To run a specific test class:
@@ -208,7 +208,7 @@ Before starting any significant feature development, establish a baseline of the
    **Failing:** [number]
    
    ## Pre-existing Failures
-   - `test_image_registration.py::test_apply_shift_and_crop_basic` - Known issue #XXX
+   - `test_<module>.py::test_<case>` - Known issue #NNN (example placeholder)
    - [other pre-existing failures]
    
    ## Critical Tests to Monitor
@@ -320,14 +320,14 @@ class TestSubsamplingParameter(unittest.TestCase):
 
 ## Continuous Integration
 
-Tests are automatically run on pull requests. Ensure all tests pass before merging changes.
+`main` is gated: PRs merge only when the required `pytest-cpu` check is green. See [docs/ci.md](ci.md) for the authoritative gate scope, how to reproduce the CI run locally, and the exclusion-baseline ratchet policy. A green local run does not guarantee green CI.
 
 ## Troubleshooting
 
 ### Common Issues
 
 1. **Import errors:** Ensure you're running tests from the project root
-2. **Missing dependencies:** Install test requirements with `pip install -e .[test]` (if available)
+2. **Missing dependencies:** Install the project in editable mode (`pip install -e .`) and ensure pytest is installed.
 3. **Data file not found:** Some tests require the example dataset in `ptycho/datasets/`
 4. **Slow tests:** Use `-v` flag for verbose output to identify slow tests
 
@@ -342,5 +342,6 @@ If you encounter issues with tests:
 ## Related Documentation
 
 - [README.md](../README.md) - Project overview and quick start
-- [scripts/README.md](../scripts/README.md) - Information about training and inference scripts
+- [scripts/training/README.md](../scripts/training/README.md) - Information about training scripts
+- [scripts/inference/README.md](../scripts/inference/README.md) - Information about inference scripts
 - [tests/README_PERSISTENCE_TESTS.md](../tests/README_PERSISTENCE_TESTS.md) - Specific documentation about persistence tests

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -49,7 +49,7 @@ params.cfg['gridsize'] = 2  # or whatever gridsize you're testing
 #### In Workflow Scripts (like run_complete_generalization_study.sh)
 ```bash
 # Verify the config file has the correct gridsize:
-grep gridsize configs/gridsize2_minimal.yaml
+grep gridsize <your_config>.yaml
 # Should show: gridsize: 2
 ```
 
@@ -185,7 +185,7 @@ python -c "from ptycho import params; print(params.cfg)"
 ### Verify Config File
 ```bash
 # Check gridsize in config
-python -c "import yaml; print(yaml.safe_load(open('configs/gridsize2_minimal.yaml')))"
+python -c "import yaml; print(yaml.safe_load(open('configs/comparison_config.yaml')))"
 ```
 
 ### Test Data Generation

--- a/docs/index.md
+++ b/docs/index.md
@@ -191,17 +191,17 @@ This index provides a comprehensive overview of all available documentation with
 
 ### By Task
 - **Starting a new feature**: [Developer Guide](DEVELOPER_GUIDE.md) → [Initiative Workflow](INITIATIVE_WORKFLOW_GUIDE.md)
-- **Running experiments**: [Workflow Guide](WORKFLOW_GUIDE.md) → [Commands Reference](COMMANDS_REFERENCE.md)
+- **Running experiments**: [Commands Reference](COMMANDS_REFERENCE.md)
 - **Debugging issues**: [Troubleshooting](TROUBLESHOOTING.md) → [Quick Reference Params](QUICK_REFERENCE_PARAMS.md)
-- **Understanding data**: [Data Contracts](data_contracts.md) → [Data Normalization](DATA_NORMALIZATION_GUIDE.md)
+- **Understanding data**: [Data Contracts](data_contracts.md)
 - **Fixing shape mismatches**: [Quick Reference Params](QUICK_REFERENCE_PARAMS.md) → [Troubleshooting](TROUBLESHOOTING.md)
 - **Training models**: [Training README](../scripts/training/README.md) → [Configuration Guide](CONFIGURATION.md)
-- **Evaluating models**: [Evaluation README](../scripts/evaluation/README.md) → [Model Comparison](../scripts/studies/README.md)
+- **Evaluating models**: [Model Comparison](../scripts/studies/README.md)
 
 ### By User Type
-- **New Users**: [README](../README.md) → [Workflow Guide](WORKFLOW_GUIDE.md) → [Training](../scripts/training/README.md)
+- **New Users**: [README](../README.md) → [Training](../scripts/training/README.md)
 - **Developers**: [Developer Guide](DEVELOPER_GUIDE.md) → [Testing Guide](TESTING_GUIDE.md) → [Architecture](architecture.md)
-- **Researchers**: [Generalization Studies](studies/GENERALIZATION_STUDY_GUIDE.md) → [Model Comparison](../scripts/studies/README.md)
+- **Researchers**: [Model Comparison](../scripts/studies/README.md)
 - **AI Agents**: [CLAUDE.md](../CLAUDE.md) → [Initiative Workflow](INITIATIVE_WORKFLOW_GUIDE.md) → [Developer Guide](DEVELOPER_GUIDE.md)
 
 ## Documentation Standards
@@ -212,7 +212,6 @@ When adding new documentation:
 3. Add "Use this when..." guidance
 4. Use the `<doc-ref>` XML tagging system for cross-references
 5. Ensure bidirectional linking
-6. Add to [PROJECT_STATUS.md](PROJECT_STATUS.md) if it's an initiative document
 
 ## 🔗 External Resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,17 +14,7 @@ This index provides a comprehensive overview of all available documentation with
 **Keywords:** params.cfg, initialization, gridsize, shape-mismatch, troubleshooting  
 **Use this when:** Getting shape mismatch errors, debugging configuration issues, or need to understand params.cfg initialization pattern.
 
-### [Workflow Guide](WORKFLOW_GUIDE.md)
-**Description:** Comprehensive guide covering complete PtychoPINN workflows from training through evaluation and model comparison, including common patterns and troubleshooting.  
-**Keywords:** workflow, training, evaluation, model-comparison, troubleshooting  
-**Use this when:** Starting a new project, planning experiments, or need to understand the complete train→evaluate→compare workflow.
-
 ## Project Management
-
-### [PROJECT_STATUS](PROJECT_STATUS.md)
-**Description:** Current development status tracker and active initiatives overview.  
-**Keywords:** project-status, tracking, initiatives  
-**Use this when:** Need to see current project status and active development work.
 
 ### [CLAUDE Instructions](../CLAUDE.md)
 **Description:** AI agent guidance defining critical data management rules, configuration requirements, and development conventions.  
@@ -60,6 +50,11 @@ This index provides a comprehensive overview of all available documentation with
 **Keywords:** debugging, shape-mismatch, configuration, oversampling, quick-fixes  
 **Use this when:** Encountering shape mismatch errors (especially gridsize-related), debugging configuration issues, or need quick diagnostic commands.
 
+### [CI Test Gate](ci.md)
+**Description:** Authoritative CI policy for main: PR-only merges gated by the required `pytest-cpu` check, exclusion-baseline ratchet policy, and the red-PR playbook.
+**Keywords:** ci, testing-gate, github-actions, ruleset, ratchet
+**Use this when:** Your PR is red, you need to run the CI suite locally, or you are editing the exclusion baseline.
+
 ### Configuration & Data
 
 #### [Configuration Guide](CONFIGURATION.md)
@@ -71,33 +66,6 @@ This index provides a comprehensive overview of all available documentation with
 **Description:** Official format specifications for NPZ datasets including required keys, data types, shapes, and normalization requirements.  
 **Keywords:** NPZ-format, data-contracts, normalization, diffraction, amplitude  
 **Use this when:** Creating or validating datasets, troubleshooting data format errors, or understanding amplitude vs intensity requirements.
-
-#### [Data Normalization Guide](DATA_NORMALIZATION_GUIDE.md)
-**Description:** Explains the three distinct types of normalization (physics, statistical, display) and their proper application throughout the data pipeline to avoid common scaling errors.  
-**Keywords:** normalization, intensity_scale, physics, statistical, pipeline  
-**Use this when:** Debugging normalization issues, implementing new data loading features, or resolving scaling-related bugs.
-
-#### [GridSize & n_groups Guide](GRIDSIZE_N_GROUPS_GUIDE.md) CRITICAL
-**Description:** Explains the unified n_groups parameter behavior across different gridsize values, eliminating confusion between individual images vs groups.  
-**Keywords:** n_groups, gridsize, sampling, groups, patterns  
-**Use this when:** Understanding group formation with different gridsize values or troubleshooting unexpected dataset sizes.
-
-### Specialized Topics
-
-#### [Sampling User Guide](SAMPLING_USER_GUIDE.md)
-**Description:** Comprehensive guide to flexible sampling control using n_subsample and n_groups parameters for memory management and training efficiency.  
-**Keywords:** sampling, n_subsample, n_groups, memory, reproducibility  
-**Use this when:** Controlling memory usage during training or implementing diverse sampling strategies.
-
-#### [Pty-Chi Migration Guide](PTYCHI_MIGRATION_GUIDE.md)
-**Description:** Complete migration guide for replacing Tike with pty-chi in three-way comparisons.
-**Keywords:** pty-chi, tike-replacement, performance-optimization, reconstruction  
-**Use this when:** Want to speed up iterative ptychographic reconstructions or migrate from Tike to pty-chi.
-
-#### [Memory Optimization Guide](memory.md)
-**Description:** Technical context document for Phase 5 of the Independent Sampling Control initiative detailing current implementation state and documentation gaps.  
-**Keywords:** sampling-control, phase5-context, memory-management, parameter-interpretation  
-**Use this when:** Working on Phase 5 of the sampling control initiative or need context on current implementation state.
 
 ## Workflows & Scripts
 
@@ -112,11 +80,6 @@ This index provides a comprehensive overview of all available documentation with
 **Description:** Guide for running inference with trained PtychoPINN models on test data, generating reconstruction visualizations and probe analysis.  
 **Keywords:** inference, reconstruction, visualization, model-loading, testing  
 **Use this when:** Have a trained model and want to generate reconstructions from new test data.
-
-#### [Evaluation](../scripts/evaluation/README.md) 
-**Description:** Complete single-model evaluation framework with automatic model detection, comprehensive metrics (MAE, PSNR, SSIM, FRC), alignment, and rich visualizations.  
-**Keywords:** evaluation, metrics, alignment, visualization, model-detection  
-**Use this when:** Need comprehensive quantitative analysis of a single trained model against ground truth.
 
 #### [Simulation](../scripts/simulation/README.md)
 **Description:** Two-stage modular simulation architecture for generating ptychographic datasets: Stage 1 creates object/probe inputs, Stage 2 simulates diffraction patterns.  
@@ -146,20 +109,6 @@ This index provides a comprehensive overview of all available documentation with
 **Description:** Quick reference guide for essential PtychoPINN workflows including data preparation golden paths, training, inference, evaluation, and troubleshooting commands.  
 **Keywords:** quick-reference, command-line, workflows, best-practices  
 **Use this when:** Need rapid lookup of common command patterns and want to follow established golden paths.
-
-## Studies & Analysis
-
-### Study Guides
-
-#### [Generalization Study Guide](studies/GENERALIZATION_STUDY_GUIDE.md)
-**Description:** Complete guide for running multi-model generalization studies comparing PtychoPINN and baseline performance across different training set sizes.  
-**Keywords:** generalization-study, model-comparison, training-sizes, automated-workflow  
-**Use this when:** Systematically comparing model performance across different amounts of training data.
-
-#### [Quick Reference for Studies](../scripts/studies/QUICK_REFERENCE.md)
-**Description:** Quick command reference for study scripts and workflows.  
-**Keywords:** study-scripts, quick-reference, commands  
-**Use this when:** Need quick access to study-related commands and patterns.
 
 ## Datasets & Experiments
 


### PR DESCRIPTION
Documentation consistency pass over the authority surfaces on main. No code changes.

- `docs/index.md`: remove 16 dead links (targets deleted in f8b26193 or never created); add routing entry for `docs/ci.md` (previously orphaned).
- `docs/TESTING_GUIDE.md`: point the Continuous Integration section at `docs/ci.md` instead of a stale duplicate claim; fix renamed test-module references; drop the nonexistent `.[test]` extra.
- `docs/DEVELOPER_GUIDE.md`: repoint paths from a never-executed docs reorg (`specs/`, `docs/debugging/`, `docs/development/`, `docs/workflows/`) to the real flat `docs/` files; remove references to deleted scripts and `docs/findings.md`.
- `docs/COMMANDS_REFERENCE.md`: remove the accidental whole-file markdown code fence (file never rendered); replace the `ptycho_evaluate` section (command has no entry point or implementation) with an accurate note.
- `docs/CONFIGURATION.md`: scope banner (documents the legacy `ptycho/` TF config system); correct `n_groups` default to `None`.
- `README.md`: remove references to two deleted study scripts.
- `CLAUDE.md`: adopt the current project guide (fixes the nonexistent `ptychopinn_torch` package name in all examples, wrong datagen import paths, stale repo pointer) with one field-name correction (`finetune_stage1_epochs`).

Every removal/claim was verified against the tree; post-patch link check on `docs/index.md` reports zero dead targets.